### PR TITLE
fix(ui): route overlay dialog downloads through task creation

### DIFF
--- a/apps/ui/src/components/download-form-fields.tsx
+++ b/apps/ui/src/components/download-form-fields.tsx
@@ -98,8 +98,6 @@ export function DownloadFormFields({
 
   return (
     <>
-      <input type="hidden" {...form.register("id", { valueAsNumber: true })} />
-
       {!isEdit ? (
         <FormRow htmlFor={`${formId}-single-mode`} label={t("downloadMode")}>
           <Controller

--- a/apps/ui/src/components/download-form-logic.test.ts
+++ b/apps/ui/src/components/download-form-logic.test.ts
@@ -6,6 +6,7 @@ import {
   createDownloadFormValues,
   DOWNLOAD_URL_RE,
   parseBatchDownloadRows,
+  resolveEditTaskId,
 } from "./download-form-logic";
 
 test("accepts supported download URL schemes", () => {
@@ -89,4 +90,10 @@ test("builds one task from single-download form values", () => {
       folder: "season",
     },
   ]);
+});
+
+test("treats NaN or missing ids as new tasks instead of edit targets", () => {
+  expect(resolveEditTaskId(42)).toBe(42);
+  expect(resolveEditTaskId(Number.NaN)).toBeUndefined();
+  expect(resolveEditTaskId(undefined)).toBeUndefined();
 });

--- a/apps/ui/src/components/download-form-logic.ts
+++ b/apps/ui/src/components/download-form-logic.ts
@@ -27,6 +27,14 @@ export function createDownloadFormValues(
   return { ...DEFAULT_DOWNLOAD_FORM_VALUES, ...values };
 }
 
+// The hidden id input registers with `valueAsNumber`, so react-hook-form turns
+// its empty DOM value into NaN. Treat NaN/undefined as "no task id" so the
+// overlay dialog (new task, `isEdit` layout) falls back to task creation
+// instead of PUT /api/downloads/NaN ("invalid id").
+export function resolveEditTaskId(id: number | undefined): number | undefined {
+  return typeof id === "number" && Number.isFinite(id) ? id : undefined;
+}
+
 export function parseBatchDownloadRows(text: string): BatchDownloadRow[] {
   return text
     .split(/\r?\n/)

--- a/apps/ui/src/components/download-form.tsx
+++ b/apps/ui/src/components/download-form.tsx
@@ -30,6 +30,7 @@ import { DownloadFormFields } from "./download-form-fields";
 import {
   buildDownloadTasks,
   createDownloadFormValues,
+  resolveEditTaskId,
 } from "./download-form-logic";
 
 export type { DownloadFormItem } from "@/store/download-dialog";
@@ -114,10 +115,11 @@ export default function DownloadForm({
         return;
       }
 
-      if (isEdit && values.id !== undefined) {
-        await editDownloadTask(values.id, tasks[0]);
+      const editId = resolveEditTaskId(values.id);
+      if (isEdit && editId !== undefined) {
+        await editDownloadTask(editId, tasks[0]);
         if (intent === "download-now") {
-          await startDownload(values.id);
+          await startDownload(editId);
         }
       } else {
         await createDownloadTasks(tasks, intent === "download-now");
@@ -157,6 +159,12 @@ export default function DownloadForm({
           className="space-y-4 overflow-y-auto px-6 py-5 sm:px-7"
           onSubmit={(event) => event.preventDefault()}
         >
+          {resolveEditTaskId(initialValues.id) !== undefined ? (
+            <input
+              type="hidden"
+              {...form.register("id", { valueAsNumber: true })}
+            />
+          ) : null}
           <DownloadFormFields
             advancedOpen={advancedOpen}
             form={form}


### PR DESCRIPTION
The overlay download dialog (bilibili card button, sniffed-source edit) renders DownloadForm with the isEdit layout but no task id. The hidden id input registered with valueAsNumber turned its empty DOM value into NaN, so submit hit PUT /api/downloads/NaN and Go Core rejected it with "invalid id". Resolve edit ids explicitly, register the hidden input only when a valid id exists, and fall back to task creation otherwise.